### PR TITLE
Update Services.php

### DIFF
--- a/Services.php
+++ b/Services.php
@@ -2,7 +2,7 @@
 
 use CodeIgniter\Config\Services as CoreServices;
 
-require_once( BASEPATH.'Config/Services.php' );
+require_once(APPPATH.'Config/Services.php');
 
 /**
  * Services Configuration file.


### PR DESCRIPTION
Line 5 : BASEPATH ot working in codeIgniter 4.0 rc.2 => Use of undefined constant BASEPATH - assumed 'BASEPATH' (this will throw an Error in a future version of PHP), I have replaced this by APPPATH